### PR TITLE
Fix AdjustHue overflow on negative hue shift

### DIFF
--- a/trident/data/vision_transforms.py
+++ b/trident/data/vision_transforms.py
@@ -1722,8 +1722,10 @@ class AdjustHue(VisionTransform):
         hsv_image = cv2.cvtColor(image, cv2.COLOR_RGB2HSV_FULL)
         h, s, v = np.split(hsv_image, 3, axis=-1)
         # uint8 addition take cares of rotation across boundaries
-        with np.errstate(over="ignore"):
-            h += np.uint8(self.value * 255)
+        # handle negative hue shift correctly without overflow error
+        shift = int(self.value * 255)
+        h = (h.astype(np.int16) + shift) % 256
+        h = h.astype(np.uint8)
         hsv_image = cv2.merge([h, s, v])
 
         image = cv2.cvtColor(hsv_image, cv2.COLOR_HSV2RGB_FULL)


### PR DESCRIPTION
## Summary
- fix OverflowError when applying AdjustHue with negative values

## Testing
- `python - <<'PY'
import numpy as np
from trident.data.vision_transforms import AdjustHue
img = np.zeros((10,10,3), dtype=np.uint8)
transform = AdjustHue(value=-0.1)
output = transform(img)
print(output.shape, output.dtype, output.sum())
PY` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68872e2055708330be42cf44fb22b859