### PR TITLE
Fix PyTorch summary output_shape aggregation

### DIFF
--- a/trident/backend/pytorch_backend.py
+++ b/trident/backend/pytorch_backend.py
@@ -3275,7 +3275,7 @@ def summary(model, input_specs, batch_size=1, inputs=None, device="cuda"):
             macc += float(summary[layer]["macc"].sum())
             try:
                 total_output += summary[layer]["output_shape"].numel(batch_size=batch_size) if isinstance(
-                    summary[layer]["output_shape"], TensorShape) else np.ndarray(
+                    summary[layer]["output_shape"], TensorShape) else np.array(
                     [shp.numel(batch_size=batch_size) for shp in summary[layer]["output_shape"]]).sum()
             except Exception as e:
                 print(layer)


### PR DESCRIPTION
## Summary
- fix use of `np.ndarray` in PyTorch backend summary
- verified TensorFlow backend does not use the same pattern

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b6c02b368833089e691ace42f4178