### PR TITLE
Fix circular import issue

### DIFF
--- a/trident/context.py
+++ b/trident/context.py
@@ -9,7 +9,6 @@ from collections import OrderedDict
 from functools import partial
 
 import numpy as np
-from trident.backend import dtype as Dtype
 
 _trident_context=None
 
@@ -400,6 +399,7 @@ class _Context:
         ``float16`` automatically when automatic mixed precision is enabled on
         CUDA devices.
         """
+        from trident.backend import dtype as Dtype
         device = getattr(self, 'device', None)
         dtype = getattr(Dtype, self.floatx)
         if self.amp_available and self.is_autocast_enabled and device == 'cuda':


### PR DESCRIPTION
## Summary
- resolve circular import by deferring dtype import in `context`

## Testing
- `python -c "from trident import context; ctx=context._context(); print(ctx.get_backend())"`

------
https://chatgpt.com/codex/tasks/task_e_688b7f360f7483308db1cafe4514b6e3