### PR TITLE
調整各優化器的 adjust_learning_rate 以套用到所有參數群組

### DIFF
--- a/trident/optims/pytorch_optimizers.py
+++ b/trident/optims/pytorch_optimizers.py
@@ -120,7 +120,8 @@ class Optimizer(optimizer.Optimizer):
 
         old_lr = self.param_groups[0]['lr']
         if old_lr != new_lr:
-            self.param_groups[0]['lr'] = new_lr
+            for g in self.param_groups:
+                g['lr'] = new_lr
             if verbose:
                 print('learning rate changed! ( form {0:.3e} to {1:.3e})'.format(old_lr, new_lr))
 
@@ -431,7 +432,8 @@ class SGD(optim.SGD):
 
         old_lr = self.param_groups[0]['lr']
         if old_lr != new_lr:
-            self.param_groups[0]['lr'] = new_lr
+            for g in self.param_groups:
+                g['lr'] = new_lr
             if verbose:
                 print('learning rate changed! ( form {0:.3e} to {1:.3e})'.format(old_lr, new_lr))
 
@@ -522,7 +524,8 @@ class LBFGS(lbfgs.LBFGS):
 
         old_lr = self.param_groups[0]['lr']
         if old_lr != new_lr:
-            self.param_groups[0]['lr'] = new_lr
+            for g in self.param_groups:
+                g['lr'] = new_lr
             if verbose:
                 print('learning rate changed! ( form {0:.3e} to {1:.3e})'.format(old_lr, new_lr))
 
@@ -592,7 +595,8 @@ class Adadelta(adadelta.Adadelta):
 
         old_lr = self.param_groups[0]['lr']
         if old_lr != new_lr:
-            self.param_groups[0]['lr'] = new_lr
+            for g in self.param_groups:
+                g['lr'] = new_lr
             if verbose:
                 print('learning rate changed! ( form {0:.3e} to {1:.3e})'.format(old_lr, new_lr))
 
@@ -663,7 +667,8 @@ class Adagrad(adagrad.Adagrad):
 
         old_lr = self.param_groups[0]['lr']
         if old_lr != new_lr:
-            self.param_groups[0]['lr'] = new_lr
+            for g in self.param_groups:
+                g['lr'] = new_lr
             if verbose:
                 print('learning rate changed! ( form {0:.3e} to {1:.3e})'.format(old_lr, new_lr))
 
@@ -745,7 +750,8 @@ class RMSprop(rmsprop.RMSprop):
 
         old_lr = self.param_groups[0]['lr']
         if old_lr != new_lr:
-            self.param_groups[0]['lr'] = new_lr
+            for g in self.param_groups:
+                g['lr'] = new_lr
             if verbose:
                 print('learning rate changed! ( form {0:.3e} to {1:.3e})'.format(old_lr, new_lr))
 

--- a/trident/optims/tensorflow_optimizers.py
+++ b/trident/optims/tensorflow_optimizers.py
@@ -303,7 +303,8 @@ class Optimizer(Trackable):
 
         old_lr = self.param_groups[0]['lr']
         if old_lr != new_lr:
-            self.param_groups[0]['lr'] = new_lr
+            for g in self.param_groups:
+                g['lr'] = new_lr
             if verbose:
                 print('learning rate changed! ( form {0:.3e} to {1:.3e})'.format(old_lr, new_lr))
 


### PR DESCRIPTION
## Summary
- 更新 `pytorch_optimizers` 與 `tensorflow_optimizers` 之 `adjust_learning_rate`，使其同時調整所有 parameter group 的學習率

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dc497434c8330947ad8e3a57f0af1