### PR TITLE
feat: add keepdim alias

### DIFF
--- a/trident/backend/numpy_ops.py
+++ b/trident/backend/numpy_ops.py
@@ -1330,17 +1330,19 @@ def where(flag, value_if_true, value_if_false):
 ## reduce operation
 ###########################
 
-def reduce_mean(x:_Tensor, axis=None, keepdims=False, **kwargs):
+def reduce_mean(x: _Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, dim: Optional[int] = None):
     """Computes the mean of the input tensor's elements across a specified axis or a list of specified axes.
 
     Args:
         x (np.ndarray): input tensor.
-        axis (int,list):  axis along which the reduction will be performed
-        keepdims (bool): Keep the reduced dimension or not, default True mean keep reduced dimension
-        **kwargs ():
+        axis (int or list, optional): axis along which the reduction will be performed.
+        keepdims (bool): Keep the reduced dimension or not. Defaults to ``False``.
+        keepdim (bool, optional): Alias for ``keepdims`` for PyTorch compatibility. If provided,
+            its value must match ``keepdims``. This argument may be deprecated in the future.
+        dim (int, optional): Alias of ``axis`` for PyTorch compatibility.
 
     Returns:
-
+        np.ndarray: Reduced tensor.
 
     Examples:
         >>> data = np.array(np.array([[[5,1], [20,2]],[[30,1], [40,2]],[[55,1], [60,2]]], dtype=np.float32))
@@ -1355,31 +1357,37 @@ def reduce_mean(x:_Tensor, axis=None, keepdims=False, **kwargs):
 
     """
 
-    axis = kwargs.get('dim', axis)
-    keepdims = kwargs.get('keepdim', keepdims)
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
+    if dim is not None:
+        axis = dim
     if axis is None:
         return np.mean(x)
     elif isinstance(axis, int):
-        return np.mean(x,axis=axis,keepdims=keepdims)
+        return np.mean(x, axis=axis, keepdims=keepdims)
     elif isinstance(axis, list):
         axis = sorted(axis)
         axis.reverse()
         for a in axis:
-            x =np.mean(x,axis=a, keepdims=keepdims)
+            x = np.mean(x, axis=a, keepdims=keepdims)
         return x
 
 
-def reduce_sum(x:_Tensor, axis=None, keepdims=False, **kwargs):
+def reduce_sum(x: _Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, dim: Optional[int] = None):
     """Computes the sum of the input tensor's elements across a specified axis or a list of specified axes.
 
     Args:
         x (np.ndarray): input tensor.
-        axis (int,list):  axis along which the reduction will be performed
-        keepdims (bool): Keep the reduced dimension or not, default True mean keep reduced dimension
-        **kwargs ():
+        axis (int or list, optional): axis along which the reduction will be performed.
+        keepdims (bool): Keep the reduced dimension or not. Defaults to ``False``.
+        keepdim (bool, optional): Alias for ``keepdims`` for PyTorch compatibility. If provided,
+            its value must match ``keepdims``. This argument may be deprecated in the future.
+        dim (int, optional): Alias of ``axis`` for PyTorch compatibility.
 
     Returns:
-        The sum of the input tensor's elements across a specified axis or a list of specified axes.
+        np.ndarray: The sum of the input tensor's elements across a specified axis or a list of specified axes.
 
     Examples:
         >>> data = np.array(np.array([[[5,1], [20,2]],[[30,1], [40,2]],[[55,1], [60,2]]], dtype=np.float32))
@@ -1395,23 +1403,27 @@ def reduce_sum(x:_Tensor, axis=None, keepdims=False, **kwargs):
         tensor([ 93., 126.])
 
     """
-    axis = kwargs.get('dim', axis)
-    keepdims = kwargs.get('keepdim', keepdims)
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
+    if dim is not None:
+        axis = dim
     if  x.size== 0:
         return zeros(1).astype(np.float32)
     if axis is None:
         return np.sum(x)
     elif isinstance(axis, int):
-        return np.sum(x,axis=axis, keepdims=keepdims)
+        return np.sum(x, axis=axis, keepdims=keepdims)
     elif isinstance(axis, list):
         axis = sorted(axis)
         axis.reverse()
         for a in axis:
-            x = np.sum(x,axis=a, keepdims=keepdims)
+            x = np.sum(x, axis=a, keepdims=keepdims)
         return x
 
 
-def reduce_max(x:_Tensor, axis=None, keepdims=False, **kwargs):
+def reduce_max(x: _Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, dim: Optional[int] = None):
     """Computes the maximum of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -1452,25 +1464,29 @@ def reduce_max(x:_Tensor, axis=None, keepdims=False, **kwargs):
         tensor(inf, shape=(), dtype=float32)
 
     """
-    axis = kwargs.get('dim', axis)
-    keepdims = kwargs.get('keepdim', keepdims)
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
+    if dim is not None:
+        axis = dim
     if  x.size== 0:
         return zeros(1).astype(np.float32)
     if axis is None:
         return np.max(x)
     elif isinstance(axis, int):
-        arr= np.max(x,axis=axis, keepdims=keepdims)
+        arr = np.max(x, axis=axis, keepdims=keepdims)
         return arr
     elif isinstance(axis, list):
         axis = sorted(axis)
         axis.reverse()
         for a in axis:
-            arr= np.max(x,axis=a, keepdims=keepdims)
+            arr = np.max(x, axis=a, keepdims=keepdims)
             x = arr
         return x
 
 
-def reduce_min(x:_Tensor, axis=None, keepdims=False, **kwargs):
+def reduce_min(x: _Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, dim: Optional[int] = None):
     """Computes the minimum of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -1512,25 +1528,29 @@ def reduce_min(x:_Tensor, axis=None, keepdims=False, **kwargs):
         tensor(inf, shape=(), dtype=float32)
 
     """
-    axis = kwargs.get('dim', axis)
-    keepdims = kwargs.get('keepdim', keepdims)
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
+    if dim is not None:
+        axis = dim
     if  x.size== 0:
         return zeros(1).astype(np.float32)
     if axis is None:
         return np.min(x)
     elif isinstance(axis, int):
-        arr= np.min(x,axis=axis, keepdims=keepdims)
+        arr = np.min(x, axis=axis, keepdims=keepdims)
         return arr
     elif isinstance(axis, list):
         axis = sorted(axis)
         axis.reverse()
         for a in axis:
-            arr= np.min(x,axis=a, keepdims=keepdims)
+            arr = np.min(x, axis=a, keepdims=keepdims)
             x = arr
         return x
 
 
-def reduce_logsumexp(x:_Tensor, axis=None, keepdims=False, **kwargs):
+def reduce_logsumexp(x: _Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, dim: Optional[int] = None):
     """Computes log(sum(exp(elements across dimensions of a tensor))).
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -1559,11 +1579,20 @@ def reduce_logsumexp(x:_Tensor, axis=None, keepdims=False, **kwargs):
         axis (int, list, tuple): The dimensions to reduce. If `None` (the default), reduces all dimensions. Must be
         in the range `[-rank(input_tensor), rank(input_tensor))`.
         keepdims (bool): If true, retains reduced dimensions with length 1.
+        keepdim (bool, optional): Alias for ``keepdims`` for PyTorch compatibility. If provided,
+            its value must match ``keepdims``. This argument may be deprecated in the future.
+        dim (int, optional): Alias of ``axis`` for PyTorch compatibility.
 
     Returns:
       The reduced tensor.
 
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
+    if dim is not None:
+        axis = dim
     if  x.size== 0:
         return zeros(1).astype(np.float32)
     if axis is None:
@@ -1572,7 +1601,7 @@ def reduce_logsumexp(x:_Tensor, axis=None, keepdims=False, **kwargs):
         return log(reduce_sum(exp(x), axis=axis, keepdims=keepdims))
 
 
-def reduce_prod(x:_Tensor, axis=None, keepdims=False, **kwargs):
+def reduce_prod(x: _Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, dim: Optional[int] = None):
     """Computes the product of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -1597,39 +1626,24 @@ def reduce_prod(x:_Tensor, axis=None, keepdims=False, **kwargs):
     Equivalent to np.prod
     @end_compatibility
     """
-    axis = kwargs.get('dim', axis)
-    keepdims = kwargs.get('keepdim', keepdims)
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
+    if dim is not None:
+        axis = dim
     if  x.size== 0:
         return zeros(1).astype(np.float32)
     if axis is None:
         return None
     if isinstance(axis, int):
-        arr, idx = np.prod(x,axis=axis, keepdims=keepdims)
+        arr, idx = np.prod(x, axis=axis, keepdims=keepdims)
         return arr
     elif isinstance(axis, list):
         axis = sorted(axis)
         axis.reverse()
         for a in axis:
-            arr, idx = np.prod(x,axis=a, keepdims=keepdims)
-            x = arr
-        return x
-
-
-    axis = kwargs.get('dim', axis)
-    keepdims = kwargs.get('keepdim', keepdims)
-    if  x.size== 0:
-        return zeros(1).astype(np.float32)
-    x=greater(x,0)
-    if axis is None:
-        return np.any(x,keepdims=keepdims)
-    if isinstance(axis, int):
-        arr, idx = np.any(x,axis=axis, keepdims=keepdims)
-        return arr
-    elif isinstance(axis, list):
-        axis = sorted(axis)
-        axis.reverse()
-        for a in axis:
-            arr, idx = np.any(x,axis=a, keepdims=keepdims)
+            arr, idx = np.prod(x, axis=a, keepdims=keepdims)
             x = arr
         return x
 
@@ -2283,40 +2297,54 @@ def gpt_gelu(x):
 ## normalization operation
 ###########################
 
-def moments(x:_Tensor, axis, keepdims=True):
-    """
+def moments(x: _Tensor, axis, keepdims: bool = True, *, keepdim: Optional[bool] = None):
+    """Computes the mean and variance of ``x`` along ``axis``.
 
     Args:
-        keepdims ():
-        x (np.ndarray): input tensor.
-        axis (int) :
+        x (np.ndarray): Input tensor.
+        axis (int or sequence): Axes along which moments are computed.
+        keepdims (bool): Whether to retain reduced dimensions. Defaults to ``True``.
+        keepdim (bool, optional): Alias for ``keepdims`` for PyTorch compatibility. If provided,
+            its value must match ``keepdims``. This argument may be deprecated in the future.
 
     Returns:
-        (np.ndarray): output tensor and have same shape with x.
-
+        Tuple[np.ndarray, np.ndarray]: Mean and variance of ``x``.
 
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     _axes = list(axis)
     norm_mean = reduce_mean(x, axis=_axes, keepdims=keepdims)
     norm_variance = reduce_mean(square(x - norm_mean), axis=_axes, keepdims=keepdims)
     return norm_mean, norm_variance
 
 
-def l2_normalize(x: np.ndarray, axis=1, keepdims=True, eps=epsilon()):
-    """
+
+def l2_normalize(x: np.ndarray, axis=1, keepdims: bool = True, eps=epsilon(), *, keepdim: Optional[bool] = None):
+    """L2 normalizes ``x`` along ``axis``.
 
     Args:
         x (np.ndarray): input tensor.
+        axis (int, optional): Axis to normalize. Defaults to ``1``.
+        keepdims (bool): Whether to retain reduced dimensions. Defaults to ``True``.
+        eps (float): Small epsilon to avoid divide-by-zero.
+        keepdim (bool, optional): Alias for ``keepdims`` for PyTorch compatibility. If provided,
+            its value must match ``keepdims``. This argument may be deprecated in the future.
 
     Returns:
         (np.ndarray): output tensor and have same shape with x.
 
-
-
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     if ndim(x) == 1:
         axis = 0
-    return x / np.sqrt(np.sum(np.square(x),axis=axis,keepdims=keepdims) + eps)
+    return x / np.sqrt(np.sum(np.square(x), axis=axis, keepdims=keepdims) + eps)
+
 
 
 ############################

--- a/trident/backend/tensorflow_ops.py
+++ b/trident/backend/tensorflow_ops.py
@@ -2110,7 +2110,7 @@ def where(flag, value_if_true=None, value_if_false=None, name='where'):
 # reduce operation
 ###########################
 @numpy_compatible
-def reduce_mean(x: Tensor, axis=None, keepdims=False, name='reduce_mean'):
+def reduce_mean(x: Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, name='reduce_mean'):
     """Computes the mean of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis` by computing the
@@ -2138,6 +2138,8 @@ def reduce_mean(x: Tensor, axis=None, keepdims=False, name='reduce_mean'):
         dimensions. Must be in the range `[-rank(input_tensor),
         rank(input_tensor))`.
       keepdims: If true, retains reduced dimensions with length 1.
+      keepdim: Alias for ``keepdims`` for PyTorch compatibility. If provided, its
+        value must match ``keepdims``. This argument may be deprecated in the future.
       name: A name for the operation (optional).
 
     Returns:
@@ -2160,13 +2162,17 @@ def reduce_mean(x: Tensor, axis=None, keepdims=False, name='reduce_mean'):
 
     @end_compatibility
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     if x.dtype == Dtype.bool:
         x = cast(x, Dtype.float)
     return tf.math.reduce_mean(x, axis=axis, keepdims=keepdims, name=name)
 
 
 @numpy_compatible
-def reduce_sum(x: Tensor, axis=None, keepdims=False, name='reduce_sum'):
+def reduce_sum(x: Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, name='reduce_sum'):
     """Computes the sum of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -2215,6 +2221,8 @@ def reduce_sum(x: Tensor, axis=None, keepdims=False, name='reduce_sum'):
         dimensions. Must be in the range `[-rank(input_tensor),
         rank(input_tensor)]`.
       keepdims: If true, retains reduced dimensions with length 1.
+      keepdim: Alias for ``keepdims`` for PyTorch compatibility. If provided, its
+        value must match ``keepdims``. This argument may be deprecated in the future.
       name: A name for the operation (optional).
 
     Returns:
@@ -2226,6 +2234,10 @@ def reduce_sum(x: Tensor, axis=None, keepdims=False, name='reduce_sum'):
     @end_compatibility
     """
 
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     if x.dtype == Dtype.bool:
         x = cast(x, Dtype.float)
     _xdtype = x.dtype
@@ -2236,7 +2248,7 @@ def reduce_sum(x: Tensor, axis=None, keepdims=False, name='reduce_sum'):
 
 
 @numpy_compatible
-def reduce_max(x: Tensor, axis=None, keepdims=False, name='reduce_max'):
+def reduce_max(x: Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, name='reduce_max'):
     """Computes the maximum of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -2256,6 +2268,8 @@ def reduce_max(x: Tensor, axis=None, keepdims=False, name='reduce_max'):
         dimensions. Must be in the range `[-rank(input_tensor),
         rank(input_tensor))`.
       keepdims: If true, retains reduced dimensions with length 1.
+      keepdim: Alias for ``keepdims`` for PyTorch compatibility. If provided, its
+        value must match ``keepdims``. This argument may be deprecated in the future.
       name (str): op name
 
     Returns:
@@ -2279,11 +2293,15 @@ def reduce_max(x: Tensor, axis=None, keepdims=False, name='reduce_max'):
         Tensor(inf, shape=(), dtype=float32)
 
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     return tf.math.reduce_max(x, axis=axis, keepdims=keepdims, name=name)
 
 
 @numpy_compatible
-def reduce_min(x: Tensor, axis=None, keepdims=False, name='reduce_min'):
+def reduce_min(x: Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, name='reduce_min'):
     """Computes the minimum of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -2303,6 +2321,8 @@ def reduce_min(x: Tensor, axis=None, keepdims=False, name='reduce_min'):
         dimensions. Must be in the range `[-rank(input_tensor),
         rank(input_tensor))`.
       keepdims: If true, retains reduced dimensions with length 1.
+      keepdim: Alias for ``keepdims`` for PyTorch compatibility. If provided, its
+        value must match ``keepdims``. This argument may be deprecated in the future.
       name (str): op name
 
     Returns:
@@ -2326,11 +2346,15 @@ def reduce_min(x: Tensor, axis=None, keepdims=False, name='reduce_min'):
         Tensor(inf, shape=(), dtype=float32)
 
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     return tf.math.reduce_min(x, axis=axis, keepdims=keepdims, name=name)
 
 
 @numpy_compatible
-def reduce_std(x: Tensor, axis=None, keepdims=False, name='reduce_min'):
+def reduce_std(x: Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, name='reduce_min'):
     """Computes the minimum of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -2350,6 +2374,8 @@ def reduce_std(x: Tensor, axis=None, keepdims=False, name='reduce_min'):
         dimensions. Must be in the range `[-rank(input_tensor),
         rank(input_tensor))`.
       keepdims: If true, retains reduced dimensions with length 1.
+      keepdim: Alias for ``keepdims`` for PyTorch compatibility. If provided, its
+        value must match ``keepdims``. This argument may be deprecated in the future.
       name (str): op name
 
     Returns:
@@ -2373,11 +2399,15 @@ def reduce_std(x: Tensor, axis=None, keepdims=False, name='reduce_min'):
         Tensor(inf, shape=(), dtype=float32)
 
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     return tf.math.reduce_std(x, axis=axis, keepdims=keepdims, name=name)
 
 
 @numpy_compatible
-def reduce_logsumexp(x: Tensor, axis=None, keepdims=False, name='reduce_logsumexp'):
+def reduce_logsumexp(x: Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, name='reduce_logsumexp'):
     """Computes log(sum(exp(elements across dimensions of a tensor))).
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -2404,7 +2434,9 @@ def reduce_logsumexp(x: Tensor, axis=None, keepdims=False, name='reduce_logsumex
     Args:
         x (tf.tensor): Input_tensor,the tensor to reduce. Should have numeric type.
         axis (int, list, tuple): The dimensions to reduce. If `None` (the default), reduces all dimensions. Must be in the range `[-rank(input_tensor), rank(input_tensor))`.
-        keepdims (bool): If true, retains reduced dimensions with length 1.
+      keepdims (bool): If true, retains reduced dimensions with length 1.
+      keepdim (bool, optional): Alias for ``keepdims`` for PyTorch compatibility. If provided,
+        its value must match ``keepdims``. This argument may be deprecated in the future.
         name (str): op name
 
     Returns:
@@ -2413,11 +2445,15 @@ def reduce_logsumexp(x: Tensor, axis=None, keepdims=False, name='reduce_logsumex
     """
     if x.dtype == Dtype.bool:
         x = cast(x, Dtype.float)
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     return tf.math.reduce_logsumexp(x, axis=axis, keepdims=keepdims, name=name)
 
 
 @numpy_compatible
-def reduce_prod(x: Tensor, axis=None, keepdims=False, name='reduce_prod'):
+def reduce_prod(x: Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, name='reduce_prod'):
     """Computes the product of elements across dimensions of a tensor.
 
     Reduces `input_tensor` along the dimensions given in `axis`.
@@ -2434,6 +2470,8 @@ def reduce_prod(x: Tensor, axis=None, keepdims=False, name='reduce_prod'):
         dimensions. Must be in the range `[-rank(input_tensor),
         rank(input_tensor))`.
       keepdims: If true, retains reduced dimensions with length 1.
+      keepdim: Alias for ``keepdims`` for PyTorch compatibility. If provided, its
+        value must match ``keepdims``. This argument may be deprecated in the future.
       name (str): op name
 
     Returns:
@@ -2443,11 +2481,19 @@ def reduce_prod(x: Tensor, axis=None, keepdims=False, name='reduce_prod'):
     Equivalent to np.prod
     @end_compatibility
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     return tf.math.reduce_prod(x, axis=axis, keepdims=keepdims, name=name)
 
 
 @numpy_compatible
-def reduce_any(x: Tensor, axis=None, keepdims=False, name='reduce_prod'):
+def reduce_any(x: Tensor, axis=None, keepdims: bool = False, *, keepdim: Optional[bool] = None, name='reduce_prod'):
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     x = tf.greater(x, 0)
     return tf.math.reduce_any(x, axis=axis, keepdims=keepdims, name=name)
 
@@ -3167,7 +3213,7 @@ def gpt_gelu(x: Tensor, name='gpt_gelu'):
 # normalization operation
 ###########################
 @numpy_compatible
-def moments(x: Tensor, axis, keepdims=True):
+def moments(x: Tensor, axis, keepdims: bool = True, *, keepdim: Optional[bool] = None):
     """Calculates the mean and variance of `x`.
 
       The mean and variance are calculated by aggregating the contents of `x`
@@ -3193,17 +3239,25 @@ def moments(x: Tensor, axis, keepdims=True):
       Returns:
         Two `Tensor` objects: `mean` and `variance`.
       """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     return tf.nn.moments(x, axes=axis, keepdims=keepdims)
 
 
-def norm(x: Tensor, order=None, axis=-1, keepdims=False):
+def norm(x: Tensor, order=None, axis=-1, keepdims: bool = False, *, keepdim: Optional[bool] = None):
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     if order is None:
         order = 'euclidean'
     return tf.norm(x, ord=order, axis=axis, keepdims=keepdims)
 
 
 @numpy_compatible
-def l2_normalize(x: Tensor, axis=-1, keepdims=True, eps=epsilon()):
+def l2_normalize(x: Tensor, axis=-1, keepdims: bool = True, eps=epsilon(), *, keepdim: Optional[bool] = None):
     """
 
     Args:
@@ -3224,6 +3278,10 @@ def l2_normalize(x: Tensor, axis=-1, keepdims=True, eps=epsilon()):
         >>> reduce_mean(l2_normalize(b)-tf.nn.l2_normalize(b)).numpy()
         0.0
     """
+    if keepdim is not None:
+        if keepdims != keepdim:
+            raise ValueError("keepdims and keepdim 不可同時指定不同值")
+        keepdims = keepdim
     return x / (tf.norm(x, keepdims=keepdims) + eps)
 
 


### PR DESCRIPTION
## Summary
- add `keepdim` alias and validation to numpy reduction utilities
- expose `keepdim` compatibility flag for TensorFlow reductions and normalizations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dc915523083309cba3320d9f94587