### PR TITLE
Skip saving on NaN/Inf and use atomic file replace for model checkpoints; stop forcing save at training end

### DIFF
--- a/tests/test_training_save_guardrails.py
+++ b/tests/test_training_save_guardrails.py
@@ -1,0 +1,23 @@
+import pathlib
+import unittest
+
+
+class TestTrainingSaveGuardrails(unittest.TestCase):
+    def test_training_end_no_longer_forces_save_model(self):
+        source = pathlib.Path('trident/optims/trainers.py').read_text(encoding='utf-8')
+        self.assertIn('def do_on_training_end(self):', source)
+        self.assertNotIn('item.save_model()', source)
+
+    def test_pytorch_save_model_skips_when_nan_or_inf_detected(self):
+        source = pathlib.Path('trident/optims/pytorch_trainer.py').read_text(encoding='utf-8')
+        self.assertIn('nan/inf detected in model weights. Skip saving.', source)
+        self.assertIn('if is_abnormal:', source)
+        self.assertIn('return False', source)
+
+    def test_pytorch_save_model_uses_atomic_replace(self):
+        source = pathlib.Path('trident/optims/pytorch_trainer.py').read_text(encoding='utf-8')
+        self.assertIn('os.replace(temp_path, target_path)', source)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trident/optims/pytorch_trainer.py
+++ b/trident/optims/pytorch_trainer.py
@@ -1072,20 +1072,29 @@ class Model(model.ModelBase,Layer):
     @measure_perf
     def save_model(self, save_path=None, **kwargs):
         is_abnormal = False
+
+        def _atomic_file_save(target_path, save_func):
+            temp_path = '{0}.{1}.tmp'.format(target_path, uuid.uuid4().hex)
+            try:
+                with open(temp_path, 'wb') as f:
+                    save_func(f)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(temp_path, target_path)
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+
         for callback in self.training_context['callbacks']:
             callback.on_model_saving_start(self.training_context)
 
         if isinstance(self._model, nn.Module) and any_abnormal_number(self._model):
             is_abnormal = True
-            for para in self._model.parameters():
-                if any_abnormal_number(para):
-                    para.data.copy_(
-                        where(is_abnormal_number(para), random_normal_like(para, mean=0, std=0.02).to(get_device()),
-                              para))
+            sys.stderr.write(self._get_name() + ' nan/inf detected in model weights. Skip saving.\n')
         if is_tensor(self._model) and any_abnormal_number(self._model):
             is_abnormal = True
 
-            sys.stderr.write(self._get_name() + '  nan detected!!\n')
+            sys.stderr.write(self._get_name() + ' nan/inf detected in tensor weights. Skip saving.\n')
         if save_path is not None:
             folder, filename, ext = split_path(save_path)
             if filename == '':
@@ -1094,7 +1103,12 @@ class Model(model.ModelBase,Layer):
         else:
             save_path = self.training_context['save_path']
 
-        if isinstance(self._model, nn.Module) and not is_abnormal:
+        if is_abnormal:
+            for callback in self.training_context['callbacks']:
+                callback.on_model_saving_end(self.training_context)
+            return False
+
+        if isinstance(self._model, nn.Module):
             try:
                 folder, filename, ext = split_path(save_path)
                 if not os.path.exists(folder):
@@ -1112,21 +1126,13 @@ class Model(model.ModelBase,Layer):
 
 
                 try:
-                    with open(save_path+'_', 'wb') as f:
-                        torch.save({
-                            'state_dict': self._model.state_dict(),
-                            'backend': 'pytorch',
-                            'trident_version': __version__,
-                            'pytorch_version': str(torch.__version__),
-                            'signature': self._model.signature
-                        }, f)
-
-                    if os.path.exists(save_path):
-                        os.remove(save_path)
-                        os.rename(save_path+'_', save_path)
-                    else:
-                        shutil.move(save_path+'_', save_path)
-
+                    _atomic_file_save(save_path, lambda f: torch.save({
+                        'state_dict': self._model.state_dict(),
+                        'backend': 'pytorch',
+                        'trident_version': __version__,
+                        'pytorch_version': str(torch.__version__),
+                        'signature': self._model.signature
+                    }, f))
                 except Exception as e:
                     ctx.print(e)
 
@@ -1135,14 +1141,7 @@ class Model(model.ModelBase,Layer):
 
 
                 try:
-                    with open(save_path+'_', 'wb') as f:
-                        save(self._model, f)
-
-                    if os.path.exists(save_path):
-                        os.remove(save_path)
-                        os.rename(save_path+'_', save_path)
-                    else:
-                        shutil.move(save_path+'_', save_path)
+                    _atomic_file_save(save_path, lambda f: save(self._model, f))
                 except Exception as e:
                     ctx.print(e)
 
@@ -1157,7 +1156,7 @@ class Model(model.ModelBase,Layer):
                 PrintException()
                 gc.collect()
 
-        elif is_tensor(self._model) and not is_abnormal:
+        elif is_tensor(self._model):
             folder, filename, ext = split_path(save_path)
             if not os.path.exists(folder):
                 folder = os.path.join(get_trident_dir(), 'models')
@@ -1175,14 +1174,9 @@ class Model(model.ModelBase,Layer):
             try:
                 numpy_model = to_numpy(self._model)
                 np.save(temppath, numpy_model)
-                if os.path.exists(save_path):
-                    os.remove(save_path)
-                    shutil.move(temppath, save_path)
-                    # os.rename(move_path, save_path)
-                else:
-                    shutil.move(temppath, save_path)
-                    sys.stdout.write(
-                        'Yor model is a Tensor not a tf.Module, it has saved as numpy array(*.npy) successfully. ')
+                os.replace(temppath, save_path)
+                sys.stdout.write(
+                    'Yor model is a Tensor not a tf.Module, it has saved as numpy array(*.npy) successfully. ')
             except Exception as e:
                 ctx.print(e)
                 if os.path.exists(temppath):
@@ -2243,17 +2237,25 @@ class LanguageModel(Model):
 
     def save_model(self, save_path=None, **kwargs):
         is_abnormal = False
+
+        def _atomic_file_save(target_path, save_func):
+            temp_path = '{0}.{1}.tmp'.format(target_path, uuid.uuid4().hex)
+            try:
+                with open(temp_path, 'wb') as f:
+                    save_func(f)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(temp_path, target_path)
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+
         for callback in self.training_context['callbacks']:
             callback.on_model_saving_start(self.training_context)
 
         if isinstance(self._model, nn.Module) and any_abnormal_number(self._model):
             is_abnormal = True
-            for para in self._model.parameters():
-                if any_abnormal_number(para):
-                    para.data.copy_(
-                        where(is_nan(para), random_normal_like(para, mean=0, std=0.02).to(get_device()), para))
-
-            sys.stderr.write(self._get_name() + '  nan detected!!\n')
+            sys.stderr.write(self._get_name() + ' nan/inf detected in model weights. Skip saving.\n')
         if save_path is not None:
             folder, filename, ext = split_path(save_path)
             if filename == '':
@@ -2262,53 +2264,57 @@ class LanguageModel(Model):
         else:
             save_path = self.training_context['save_path']
 
-        if isinstance(self._model, nn.Module) and not is_abnormal:
+        if is_abnormal:
+            for callback in self.training_context['callbacks']:
+                callback.on_model_saving_end(self.training_context)
+            return False
+
+        if isinstance(self._model, nn.Module):
             try:
                 folder, filename, ext = split_path(save_path)
                 if filename == '':
                     filename = self.name
 
-                ext = '.pth.tar_'
+                ext = '.pth.tar'
                 save_path = os.path.join(folder, filename + ext)
                 make_dir_if_need(sanitize_path(save_path))
                 save_path = sanitize_path(save_path)
                 device = get_device()
                 self._model.eval()
                 self._model.cpu()
-                torch.save({
+                _atomic_file_save(save_path, lambda f: torch.save({
                     'state_dict': self._model.state_dict(),
                     'vocabs': self.vocabs,
                     'backend': 'pytorch',
                     'trident_version': __version__,
                     'pytorch_version': torch.__version__,
                     'signature': self._model.signature
-                }, save_path)
+                }, f))
 
-                shutil.copy2(save_path, save_path.replace('.pth.tar_', '.pth.tar'))
-                os.remove(save_path)
-                save_path = save_path.replace('pth.tar_', 'pth_')
-                save(self._model, save_path)
-                shutil.copy2(save_path, save_path.replace('.pth_', '.pth'))
-                os.remove(save_path)
+                save_path = save_path.replace('.pth.tar', '.pth')
+                _atomic_file_save(save_path, lambda f: save(self._model, f))
                 self._model.train()
                 self._model.to(device)
             except Exception as e:
                 ctx.print(e)
                 PrintException()
 
-        elif isinstance(self._model, torch.Tensor) and not is_abnormal:
+        elif isinstance(self._model, torch.Tensor):
             folder, filename, ext = split_path(save_path)
             if filename == '':
                 filenam = self.name
 
-            ext = '.npy_'
+            ext = '.npy'
             save_path = os.path.join(folder, filename + ext)
             make_dir_if_need(sanitize_path(save_path))
             save_path = sanitize_path(save_path)
             numpy_model = to_numpy(self._model)
-            np.save(save_path, numpy_model)
-            shutil.copy2(save_path, save_path.replace('.npy_', '.npy'))
-            os.remove(save_path)
+            temppath = '{0}.{1}.tmp'.format(save_path, uuid.uuid4().hex)
+            with open(temppath, 'wb') as f:
+                np.save(f, numpy_model)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temppath, save_path)
             sys.stdout.write('Yor model is a Tensor not a nn.Module, it has saved as numpy array(*.npy) successfully. ')
         else:
             raise ValueError(

--- a/trident/optims/trainers.py
+++ b/trident/optims/trainers.py
@@ -497,7 +497,6 @@ class TrainingPlan(object):
         for callback in self.callbacks:
             callback.on_training_end(self.__dict__)
         for item in self.training_items.value_list:
-            item.save_model()
             item.eval()
 
     def do_on_overall_epoch_end(self):
@@ -701,6 +700,8 @@ class TrainingPlan(object):
                             if is_epoch_end:
                                 self.do_on_overall_epoch_end()
 
+                            # `current_batch` is zero-based and resets every epoch, so
+                            # frequency=100 triggers on each epoch's 100th batch.
                             if self.save_model_frequency > 0 and self.save_model_unit == 'batch' and (
                                     current_batch + 1) % \
                                     self.save_model_frequency == 0:


### PR DESCRIPTION
### Motivation
- Prevent corrupted or partial model files when abnormal values are present by skipping save and provide clear diagnostics. 
- Make model checkpointing atomic to avoid leaving partial files on disk and to improve robustness during concurrent or interrupted writes. 
- Stop forcing a final save for every training item at training end to give users better control over when models are persisted. 

### Description
- Added unit tests in `tests/test_training_save_guardrails.py` that assert `do_on_training_end` no longer calls `save_model()`, that PyTorch saving logs and returns early on NaN/Inf, and that atomic `os.replace` is used. 
- In `trident/optims/pytorch_trainer.py` introduced an `_atomic_file_save` helper that writes to a UUID-temporary file, calls `f.flush()` and `os.fsync()`, and then uses `os.replace()` to atomically move the temp file to the target path, and cleans up temp files on error. 
- Modified `save_model` for both the main model and `LanguageModel` to detect abnormal numbers with `any_abnormal_number(...)`, emit a stderr message, invoke callbacks, and return `False` instead of saving when abnormalities are found. 
- Replaced previous ad-hoc temporary file handling and non-atomic rename/move sequences with the `_atomic_file_save` approach for both `.pth.tar`/`.pth` and `.npy` outputs, and removed attempts to overwrite NaN/Inf parameters with random values. 
- In `trident/optims/trainers.py` removed the unconditional `item.save_model()` call from `do_on_training_end()` so items are now only `eval()`-ed at the end, and ensured periodic batch-based saves still occur according to `save_model_frequency` and `save_model_unit`. 

### Testing
- Ran the new test suite with `python -m unittest discover -v tests` which executed `tests/test_training_save_guardrails.py` and the assertions passed. 
- No other automated tests were modified for this change and the above tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48ac6176c8330b62778a6a8fcc118)