### PR TITLE
Guard PyTorch trainer graph init when module signature is missing

### DIFF
--- a/tests/test_pytorch_trainer_signature_guard.py
+++ b/tests/test_pytorch_trainer_signature_guard.py
@@ -1,0 +1,13 @@
+import pathlib
+import unittest
+
+
+class TestPytorchTrainerSignatureGuard(unittest.TestCase):
+    def test_initial_graph_recovers_missing_signature(self):
+        source = pathlib.Path('trident/optims/pytorch_trainer.py').read_text(encoding='utf-8')
+        self.assertIn("if not hasattr(output, 'signature') or output.signature is None:", source)
+        self.assertIn('output._signature = get_signature(output)', source)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trident/optims/pytorch_trainer.py
+++ b/trident/optims/pytorch_trainer.py
@@ -153,6 +153,10 @@ class Model(model.ModelBase,Layer):
             if not isinstance(output, Layer):
                 output = fix_pytorch_module(output, input_shape=input_shape, input_tensor=inputs)
             output.train()
+            if not hasattr(output, 'signature') or output.signature is None:
+                output._signature = get_signature(output)
+                if hasattr(output, 'signature'):
+                    output.signature = output._signature
             # c._signature = get_signature(output)
 
 


### PR DESCRIPTION
### Motivation
- Prevent a crash where a PyTorch `Sequential`/module reaches the trainer `_initial_graph` without an initialized `signature` and causes `AttributeError` when trainer code accesses `output.signature.inputs`.

### Description
- Add a defensive recovery in `trident/optims/pytorch_trainer.py` that calls `get_signature(output)` and sets `output._signature` (and `output.signature` when possible) if `output` has no `signature` or it is `None`, and add `tests/test_pytorch_trainer_signature_guard.py` to ensure the guard remains present.

### Testing
- Ran `python -m unittest discover -s tests -p "test_*.py"` and all tests passed (`9 tests, OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06b001d0083309a0ca9d39f03820f)