### PR TITLE
Guard missing model signature in ImageClassificationModel

### DIFF
--- a/tests/test_pytorch_trainer_signature_guard.py
+++ b/tests/test_pytorch_trainer_signature_guard.py
@@ -8,6 +8,10 @@ class TestPytorchTrainerSignatureGuard(unittest.TestCase):
         self.assertIn("if not hasattr(output, 'signature') or output.signature is None:", source)
         self.assertIn('output._signature = get_signature(output)', source)
 
+    def test_image_classification_model_uses_safe_signature_lookup(self):
+        source = pathlib.Path('trident/optims/pytorch_trainer.py').read_text(encoding='utf-8')
+        self.assertIn("model_signature = getattr(self._model, 'signature', None)", source)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/trident/optims/pytorch_trainer.py
+++ b/trident/optims/pytorch_trainer.py
@@ -1876,12 +1876,13 @@ class ImageClassificationModel(Model):
         self._idx2lab = {}
         self._lab2idx = {}
 
-        if self._model.signature is not None and len(self._model.signature.inputs.value_list) > 0 and \
-                self._model.signature.inputs.value_list[0].object_type is None:
-            self._model.signature.inputs.value_list[0].object_type = ObjectType.rgb
-        if self._model.signature is not None and len(self._model.signature.outputs.value_list) > 0 and \
-                self._model.signature.outputs.value_list[0].object_type is None:
-            self._model.signature.outputs.value_list[0].object_type = ObjectType.classification_label
+        model_signature = getattr(self._model, 'signature', None)
+        if model_signature is not None and len(model_signature.inputs.value_list) > 0 and \
+                model_signature.inputs.value_list[0].object_type is None:
+            model_signature.inputs.value_list[0].object_type = ObjectType.rgb
+        if model_signature is not None and len(model_signature.outputs.value_list) > 0 and \
+                model_signature.outputs.value_list[0].object_type is None:
+            model_signature.outputs.value_list[0].object_type = ObjectType.classification_label
 
     @property
     def class_names(self):


### PR DESCRIPTION
### Motivation
- Prevent an `AttributeError` when a wrapped PyTorch module (for example `nn.Sequential`) does not expose a `signature` attribute by performing a safe lookup before accessing it.

### Description
- Replace direct `self._model.signature` access in `ImageClassificationModel.__init__` with `model_signature = getattr(self._model, 'signature', None)` and use `model_signature` for input/output `object_type` initialization in `trident/optims/pytorch_trainer.py`.
- Add a regression unit test `test_image_classification_model_uses_safe_signature_lookup` to `tests/test_pytorch_trainer_signature_guard.py` to lock in the safe lookup pattern.

### Testing
- Ran `python -m unittest discover -s tests -p "test_*.py"` and all tests passed (`Ran 10 tests in 0.020s`, `OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0730c72388330a4e10b8c7f9673e5)